### PR TITLE
MAC_Hints: `OSX`, `MAC` should be `macOS`

### DIFF
--- a/Help/MAC_Hints.rst
+++ b/Help/MAC_Hints.rst
@@ -1,4 +1,4 @@
-Coverage Installation Hints for OSX Users:
+Coverage Installation Hints for macOS Users:
 ==========================================
 
 1. Make sure you have installed Xcode and Homebrew.


### PR DESCRIPTION
Replaces OSX, MAC with macOS.

Closes https://github.com/coala/documentation/issues/254
